### PR TITLE
fix: changing educations links to open in new tab

### DIFF
--- a/adversarial_apps/src/app/education/cfr-title-15/page.tsx
+++ b/adversarial_apps/src/app/education/cfr-title-15/page.tsx
@@ -23,7 +23,7 @@ export default function page(){
             <p className = "pl-5"><br />The goal of CFR Title 15 is to ensure that companies which will be 
                 contracted by the U.S. have no affiliation with foreign countries that the U.S. deems as adversaries. 
                 Specifically, this section will go over what is addressed in Part 791: <a href=
-                "https://www.ecfr.gov/current/title-15/subtitle-B/chapter-VII/subchapter-E/part-791"> <u>Part 791 Link</u></a></p>
+                "https://www.ecfr.gov/current/title-15/subtitle-B/chapter-VII/subchapter-E/part-791" target="_blank"> <u>Part 791 Link</u></a></p>
 
             <p className = "pl-5"><br />Part 791.1 outlines the purpose of this section, which is to determine 
                 how CFR deals with software on a security front. It defines how authorities will handle software that 

--- a/adversarial_apps/src/app/education/cmmc/page.tsx
+++ b/adversarial_apps/src/app/education/cmmc/page.tsx
@@ -14,7 +14,7 @@ export default function page(){
             Third-Party Assessment Organization (C3PAO). Unlike CMMC, NIST 800-171 assessments can be self-reported 
             and are submitted to meet DoD contractor requirements.</p>
         <p className = "pl-5"><br />More information can be found here from the DoD&apos;s CIO website:
-            <a href="https://dodcio.defense.gov/cmmc/About/"> <u>CMMC 2.0 About Page</u></a></p>
+            <a href="https://dodcio.defense.gov/cmmc/About/" target="_blank"> <u>CMMC 2.0 About Page</u></a></p>
     </main>
     );
 }

--- a/adversarial_apps/src/app/education/foci/page.tsx
+++ b/adversarial_apps/src/app/education/foci/page.tsx
@@ -8,15 +8,15 @@ export default function page(){
                 owner of a security &mdash; in this case a business &mdash; includes any person who 
                 directly or indirectly through any contract arrangement, understanding, relationship, or 
                 otherwise has or shares any of the following:</p>
-            <p className = "pl-10"><ol><br />
+            <ol className = "pl-10"><br />
                 <li>    1. Voting power, which includes the power to vote or to direct the voting of such security; or</li>
                 <li>    2. Investment power, which includes the power to dispose of or to direct the disposition of such security.</li>
-            </ol></p>
+            </ol>
             <p className = "pl-5"><br />In this case, security just means ownership of a portion of the business. 
                 Voting power involves any decisions an owner might make about business operations, regardless 
                 of whether that power is being actively exercised.</p>
             <p className = "pl-5"><br />For more information, please visit this page:
-                <a href="https://business.defense.gov/Resources/FOCI/"> <u>FOCI Resources Page</u></a></p>
+                <a target="_blank" href="https://business.defense.gov/Resources/FOCI/"> <u>FOCI Resources Page</u></a></p>
         </main>
     );
 }

--- a/adversarial_apps/src/app/education/resources/page.tsx
+++ b/adversarial_apps/src/app/education/resources/page.tsx
@@ -4,23 +4,23 @@ export default function page(){
             <h1 className="text-6xl font-bold pl-5">Forms and Resources</h1>
             <p className = "pl-5"><br />Navy SBIR / STTR Forms & Templates (Including Volume VII Disclosures 
                 of Foreign Affiliations or Relationships to Foreign Countries Walkthrough):
-                <a href="http://www.navysbir.com/links_forms.htm"> <u>Click here for link</u></a></p>
+                <a href="http://www.navysbir.com/links_forms.htm" target="_blank"> <u>Click here for link</u></a></p>
             <p className = "pl-5"><br />Cybersecurity Maturity Model Certification (CMMC) 2.0 FAQs:
-                <a href="https://dodcio.defense.gov/Portals/0/Documents/CMMC/CMMC-FAQs.pdf?ver=Uy1I0M3byGaIO6hN43Y_dA%3d%3d"> <u>Click here for link</u></a></p>
+                <a href="https://dodcio.defense.gov/Portals/0/Documents/CMMC/CMMC-FAQs.pdf?ver=Uy1I0M3byGaIO6hN43Y_dA%3d%3d" target="_blank"> <u>Click here for link</u></a></p>
             <p className = "pl-5"><br />Register with SAM:
-                <a href="https://sam.gov/content/entity-registration"> <u>Click here for link</u></a></p>
+                <a href="https://sam.gov/content/entity-registration" target="_blank"> <u>Click here for link</u></a></p>
             <p className = "pl-5"><br />Small Business Administration DSBS Company Lookup:
-                <a href="https://dsbs.sba.gov/search/dsp_dsbs.cfm"> <u>Click here for link</u></a></p>
+                <a href="https://dsbs.sba.gov/search/dsp_dsbs.cfm" target="_blank"> <u>Click here for link</u></a></p>
             <p className = "pl-5"><br />SBIR Due Diligence Memorandum (May 2024):
-                <a href="https://media.defense.gov/2024/May/23/2003471996/-1/-1/1/DUE_DILIGENCE_PROGRAM_OSD003584_24_RES.PDF"> <u>Click here for link</u></a></p>
+                <a href="https://media.defense.gov/2024/May/23/2003471996/-1/-1/1/DUE_DILIGENCE_PROGRAM_OSD003584_24_RES.PDF" target="_blank"> <u>Click here for link</u></a></p>
             <p className = "pl-5"><br />Due Diligence Documentation Changes in Response to Above Memorandum:
-                <a href="https://media.defense.gov/2024/Apr/16/2003440556/-1/-1/0/DOD_SBIR_24.2_BAA_PREFACE.PDF"> <u>Click here for link</u></a></p>
+                <a href="https://media.defense.gov/2024/Apr/16/2003440556/-1/-1/0/DOD_SBIR_24.2_BAA_PREFACE.PDF" target="_blank"> <u>Click here for link</u></a></p>
             <p className = "pl-5"><br />SBIR and STTR Extension Act of 2022:
-                <a href="https://www.congress.gov/117/plaws/publ183/PLAW-117publ183.pdf"> <u>Click here for link</u></a></p>
+                <a href="https://www.congress.gov/117/plaws/publ183/PLAW-117publ183.pdf" target="_blank"> <u>Click here for link</u></a></p>
             <p className = "pl-5"><br />CFR Title 15 Documentation:
-                <a href="https://www.ecfr.gov/current/title-15/"> <u>Click here for link</u></a></p>
+                <a href="https://www.ecfr.gov/current/title-15/" target="_blank"> <u>Click here for link</u></a></p>
             <p className = "pl-5"><br />Federal Acquisition Regulation (FAR) Documentation:
-                <a href="https://www.acquisition.gov/browse/index/far"> <u>Click here for link</u></a></p>
+                <a href="https://www.acquisition.gov/browse/index/far" target="_blank"> <u>Click here for link</u></a></p>
         </main>
     );
 }


### PR DESCRIPTION
# Proposed Changes

About 10 simple one-liners changing the links to open in a new tab.

Also deleted one set of <p> tags which was throwing an error because it had a set of <ol> tags inside.

Fixes # .
