### PR TITLE
feat: made navbar smaller, sticky, and added white border at bottom

### DIFF
--- a/adversarial_apps/src/components/navbar.tsx
+++ b/adversarial_apps/src/components/navbar.tsx
@@ -55,7 +55,7 @@ export default function NavBar() {
   }, []);
 
   return (
-    <header className="bg-blue-900 grid grid-cols-3 items-center p-4 shadow-md">
+    <header className="sticky top-0 bg-blue-900 grid grid-cols-3 items-center p-1 shadow-md border-b-2">
       {/* Logo */}
       <div className="flex justify-start ml-4">
         <Link href="/" aria-label="Go to home page">


### PR DESCRIPTION
# Proposed Changes

Changed the header in the NavBar component so that it is now sticky and smaller. These are changes we discussed doing before winter break. 

Also added the small white bottom border that we had in the original Figma mocks for better accessibility.

Fixes # .
