### PR TITLE
Issue/83 Education Content Organization Overhaul

### DIFF
--- a/adversarial_apps/src/app/education/cfr-title-15/page.tsx
+++ b/adversarial_apps/src/app/education/cfr-title-15/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 export default function page(){
     return (
     <>
@@ -53,6 +54,13 @@ export default function page(){
                 permissions authorities have available to them to investigate ICTS cases and the penalties 
                 for not adhering to these requirements respectively.</p>
 
+            {/* copy paste the below button(s) for each subpage */}
+            <div className="container py-10 px-10 mx-0 min-w-full flex flex-col items-center">
+                <button className="bg-blue-700 hover:bg-blue-900 text-white font-bold py-2 px-4 rounded"
+                        aria-label="Back to Education Hub">
+                    <Link href = "/education">Back to Education Hub</Link>
+                </button>
+            </div>
         </main>
     </>
     );

--- a/adversarial_apps/src/app/education/cfr-title-15/page.tsx
+++ b/adversarial_apps/src/app/education/cfr-title-15/page.tsx
@@ -54,15 +54,30 @@ export default function page(){
                 permissions authorities have available to them to investigate ICTS cases and the penalties 
                 for not adhering to these requirements respectively.</p>
 
-            {/* copy paste the below button(s) for each subpage */}
-            <div className="container py-10 px-10 mx-0 min-w-full flex flex-col items-center">
-                <Link href = "/education">
+            {/* copy paste the below buttons for each subpage; make sure to relink */}
+            <div className="container py-10 px-10 mx-0 min-w-full flex justify-center items-center space-x-4">
+                <Link href = "/education" passHref legacyBehavior>
+                    <button className="bg-blue-700 hover:bg-blue-900 text-white font-bold py-2 px-4 rounded"
+                        aria-label="Previous Page">
+                        Previous Page
+                    </button>
+                </Link>
+
+                <Link href = "/education" passHref legacyBehavior>
                     <button className="bg-blue-700 hover:bg-blue-900 text-white font-bold py-2 px-4 rounded"
                         aria-label="Back to Education Hub">
                         Back to Education Hub
                     </button>
                 </Link>
+
+                <Link href = "/education" passHref legacyBehavior>
+                    <button className="bg-blue-700 hover:bg-blue-900 text-white font-bold py-2 px-4 rounded"
+                        aria-label="Next Page">
+                        Next Page
+                    </button>
+                </Link>
             </div>
+            
         </main>
     </>
     );

--- a/adversarial_apps/src/app/education/cfr-title-15/page.tsx
+++ b/adversarial_apps/src/app/education/cfr-title-15/page.tsx
@@ -70,7 +70,7 @@ export default function page(){
                     </button>
                 </Link>
 
-                <Link href = "/education" passHref legacyBehavior>
+                <Link href = "/education/sam-compliance" passHref legacyBehavior>
                     <button className="bg-blue-700 hover:bg-blue-900 text-white font-bold py-2 px-4 rounded"
                         aria-label="Next Page">
                         Next Page

--- a/adversarial_apps/src/app/education/cfr-title-15/page.tsx
+++ b/adversarial_apps/src/app/education/cfr-title-15/page.tsx
@@ -56,12 +56,6 @@ export default function page(){
 
             {/* copy paste the below buttons for each subpage; make sure to relink */}
             <div className="container py-10 px-10 mx-0 min-w-full flex justify-center items-center space-x-4">
-                <Link href = "/education" passHref legacyBehavior>
-                    <button className="bg-blue-700 hover:bg-blue-900 text-white font-bold py-2 px-4 rounded"
-                        aria-label="Previous Page">
-                        Previous Page
-                    </button>
-                </Link>
 
                 <Link href = "/education" passHref legacyBehavior>
                     <button className="bg-blue-700 hover:bg-blue-900 text-white font-bold py-2 px-4 rounded"

--- a/adversarial_apps/src/app/education/cfr-title-15/page.tsx
+++ b/adversarial_apps/src/app/education/cfr-title-15/page.tsx
@@ -56,10 +56,12 @@ export default function page(){
 
             {/* copy paste the below button(s) for each subpage */}
             <div className="container py-10 px-10 mx-0 min-w-full flex flex-col items-center">
-                <button className="bg-blue-700 hover:bg-blue-900 text-white font-bold py-2 px-4 rounded"
+                <Link href = "/education">
+                    <button className="bg-blue-700 hover:bg-blue-900 text-white font-bold py-2 px-4 rounded"
                         aria-label="Back to Education Hub">
-                    <Link href = "/education">Back to Education Hub</Link>
-                </button>
+                        Back to Education Hub
+                    </button>
+                </Link>
             </div>
         </main>
     </>

--- a/adversarial_apps/src/app/education/cmmc/page.tsx
+++ b/adversarial_apps/src/app/education/cmmc/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 export default function page(){
     return (
     <main aria-label="main-content">
@@ -15,6 +16,14 @@ export default function page(){
             and are submitted to meet DoD contractor requirements.</p>
         <p className = "pl-5"><br />More information can be found here from the DoD&apos;s CIO website:
             <a href="https://dodcio.defense.gov/cmmc/About/" target="_blank"> <u>CMMC 2.0 About Page</u></a></p>
+
+        {/* copy paste the below button(s) for each subpage */}
+        <div className="container py-10 px-10 mx-0 min-w-full flex flex-col items-center">
+            <button className="bg-blue-700 hover:bg-blue-900 text-white font-bold py-2 px-4 rounded"
+                    aria-label="Back to Education Hub">
+                <Link href = "/education">Back to Education Hub</Link>
+            </button>
+        </div>
     </main>
     );
 }

--- a/adversarial_apps/src/app/education/cmmc/page.tsx
+++ b/adversarial_apps/src/app/education/cmmc/page.tsx
@@ -17,12 +17,26 @@ export default function page(){
         <p className = "pl-5"><br />More information can be found here from the DoD&apos;s CIO website:
             <a href="https://dodcio.defense.gov/cmmc/About/" target="_blank"> <u>CMMC 2.0 About Page</u></a></p>
 
-        {/* copy paste the below button(s) for each subpage */}
-        <div className="container py-10 px-10 mx-0 min-w-full flex flex-col items-center">
-                <Link href = "/education">
+        {/* copy paste the below buttons for each subpage; make sure to relink */}
+        <div className="container py-10 px-10 mx-0 min-w-full flex justify-center items-center space-x-4">
+                <Link href = "/education" passHref legacyBehavior>
+                    <button className="bg-blue-700 hover:bg-blue-900 text-white font-bold py-2 px-4 rounded"
+                        aria-label="Previous Page">
+                        Previous Page
+                    </button>
+                </Link>
+
+                <Link href = "/education" passHref legacyBehavior>
                     <button className="bg-blue-700 hover:bg-blue-900 text-white font-bold py-2 px-4 rounded"
                         aria-label="Back to Education Hub">
                         Back to Education Hub
+                    </button>
+                </Link>
+
+                <Link href = "/education" passHref legacyBehavior>
+                    <button className="bg-blue-700 hover:bg-blue-900 text-white font-bold py-2 px-4 rounded"
+                        aria-label="Next Page">
+                        Next Page
                     </button>
                 </Link>
             </div>

--- a/adversarial_apps/src/app/education/cmmc/page.tsx
+++ b/adversarial_apps/src/app/education/cmmc/page.tsx
@@ -19,11 +19,13 @@ export default function page(){
 
         {/* copy paste the below button(s) for each subpage */}
         <div className="container py-10 px-10 mx-0 min-w-full flex flex-col items-center">
-            <button className="bg-blue-700 hover:bg-blue-900 text-white font-bold py-2 px-4 rounded"
-                    aria-label="Back to Education Hub">
-                <Link href = "/education">Back to Education Hub</Link>
-            </button>
-        </div>
+                <Link href = "/education">
+                    <button className="bg-blue-700 hover:bg-blue-900 text-white font-bold py-2 px-4 rounded"
+                        aria-label="Back to Education Hub">
+                        Back to Education Hub
+                    </button>
+                </Link>
+            </div>
     </main>
     );
 }

--- a/adversarial_apps/src/app/education/cmmc/page.tsx
+++ b/adversarial_apps/src/app/education/cmmc/page.tsx
@@ -19,7 +19,7 @@ export default function page(){
 
         {/* copy paste the below buttons for each subpage; make sure to relink */}
         <div className="container py-10 px-10 mx-0 min-w-full flex justify-center items-center space-x-4">
-                <Link href = "/education" passHref legacyBehavior>
+                <Link href = "/education/sbir-due-diligence" passHref legacyBehavior>
                     <button className="bg-blue-700 hover:bg-blue-900 text-white font-bold py-2 px-4 rounded"
                         aria-label="Previous Page">
                         Previous Page
@@ -33,7 +33,7 @@ export default function page(){
                     </button>
                 </Link>
 
-                <Link href = "/education" passHref legacyBehavior>
+                <Link href = "/education/foci" passHref legacyBehavior>
                     <button className="bg-blue-700 hover:bg-blue-900 text-white font-bold py-2 px-4 rounded"
                         aria-label="Next Page">
                         Next Page

--- a/adversarial_apps/src/app/education/foci/page.tsx
+++ b/adversarial_apps/src/app/education/foci/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 export default function page(){
     return (
         <main aria-label="main-content">
@@ -17,6 +18,14 @@ export default function page(){
                 of whether that power is being actively exercised.</p>
             <p className = "pl-5"><br />For more information, please visit this page:
                 <a target="_blank" href="https://business.defense.gov/Resources/FOCI/"> <u>FOCI Resources Page</u></a></p>
+            
+            {/* copy paste the below button(s) for each subpage */}
+            <div className="container py-10 px-10 mx-0 min-w-full flex flex-col items-center">
+                <button className="bg-blue-700 hover:bg-blue-900 text-white font-bold py-2 px-4 rounded"
+                        aria-label="Back to Education Hub">
+                    <Link href = "/education">Back to Education Hub</Link>
+                </button>
+            </div>
         </main>
     );
 }

--- a/adversarial_apps/src/app/education/foci/page.tsx
+++ b/adversarial_apps/src/app/education/foci/page.tsx
@@ -19,12 +19,26 @@ export default function page(){
             <p className = "pl-5"><br />For more information, please visit this page:
                 <a target="_blank" href="https://business.defense.gov/Resources/FOCI/"> <u>FOCI Resources Page</u></a></p>
             
-            {/* copy paste the below button(s) for each subpage */}
-            <div className="container py-10 px-10 mx-0 min-w-full flex flex-col items-center">
-                <Link href = "/education">
+            {/* copy paste the below buttons for each subpage; make sure to relink */}
+            <div className="container py-10 px-10 mx-0 min-w-full flex justify-center items-center space-x-4">
+                <Link href = "/education" passHref legacyBehavior>
+                    <button className="bg-blue-700 hover:bg-blue-900 text-white font-bold py-2 px-4 rounded"
+                        aria-label="Previous Page">
+                        Previous Page
+                    </button>
+                </Link>
+
+                <Link href = "/education" passHref legacyBehavior>
                     <button className="bg-blue-700 hover:bg-blue-900 text-white font-bold py-2 px-4 rounded"
                         aria-label="Back to Education Hub">
                         Back to Education Hub
+                    </button>
+                </Link>
+
+                <Link href = "/education" passHref legacyBehavior>
+                    <button className="bg-blue-700 hover:bg-blue-900 text-white font-bold py-2 px-4 rounded"
+                        aria-label="Next Page">
+                        Next Page
                     </button>
                 </Link>
             </div>

--- a/adversarial_apps/src/app/education/foci/page.tsx
+++ b/adversarial_apps/src/app/education/foci/page.tsx
@@ -21,7 +21,7 @@ export default function page(){
             
             {/* copy paste the below buttons for each subpage; make sure to relink */}
             <div className="container py-10 px-10 mx-0 min-w-full flex justify-center items-center space-x-4">
-                <Link href = "/education" passHref legacyBehavior>
+                <Link href = "/education/cmmc" passHref legacyBehavior>
                     <button className="bg-blue-700 hover:bg-blue-900 text-white font-bold py-2 px-4 rounded"
                         aria-label="Previous Page">
                         Previous Page
@@ -35,7 +35,7 @@ export default function page(){
                     </button>
                 </Link>
 
-                <Link href = "/education" passHref legacyBehavior>
+                <Link href = "/education/resources" passHref legacyBehavior>
                     <button className="bg-blue-700 hover:bg-blue-900 text-white font-bold py-2 px-4 rounded"
                         aria-label="Next Page">
                         Next Page

--- a/adversarial_apps/src/app/education/foci/page.tsx
+++ b/adversarial_apps/src/app/education/foci/page.tsx
@@ -21,10 +21,12 @@ export default function page(){
             
             {/* copy paste the below button(s) for each subpage */}
             <div className="container py-10 px-10 mx-0 min-w-full flex flex-col items-center">
-                <button className="bg-blue-700 hover:bg-blue-900 text-white font-bold py-2 px-4 rounded"
+                <Link href = "/education">
+                    <button className="bg-blue-700 hover:bg-blue-900 text-white font-bold py-2 px-4 rounded"
                         aria-label="Back to Education Hub">
-                    <Link href = "/education">Back to Education Hub</Link>
-                </button>
+                        Back to Education Hub
+                    </button>
+                </Link>
             </div>
         </main>
     );

--- a/adversarial_apps/src/app/education/page.tsx
+++ b/adversarial_apps/src/app/education/page.tsx
@@ -1,25 +1,70 @@
+'use client';
+import React from "react";
 import Link from "next/link";
-export default function page(){
-    
+
+type ModuleProps = {
+    title: string;
+    children: React.ReactNode;
+};
+
+const Module: React.FC<ModuleProps> = ({ title, children }) => {
+    const id = title.replace(/\s+/g, '-').toLowerCase();
     return (
-        <>
-        <main>
-        {/*main text goes here*/}
-            <h1 className="text-6xl font-bold pl-5">Education</h1>
-            <p className="pl-5">Educate yourself on all things Government Compliance. 
-                Your Journey to secure business starts here!</p>
-                <p className="pl-5"><br /> Places to start: <br /></p>
-            
-            <ul className="list-disc pl-12">
-            <Link href = "education/cfr-title-15"><li>CFR Title 15</li></Link>
-            <Link href = "education/sam-compliance"><li>SAM Compliance</li></Link>
-            <Link href = "education/sbir-due-diligence"><li>SBIR Due Diligence</li></Link>
-            <Link href = "education/resources"><li>Resources</li></Link>
-            <Link href = "education/cmmc"><li>CMMC 2.0</li></Link>
-            <Link href = "education/foci"><li>FOCI</li></Link>
-            {/* Need to add links to each page here */}
-        </ul>
-        </main>
-        </>
+        <details className="module w-full max-w-lg mx-auto rounded-lg shadow-md overflow-hidden mb-4 border-2 border-solid">
+            <summary
+                id={`${id}-title`} 
+                className="module-header bg-blue-800 p-4 cursor-pointer flex justify-between items-center text-lg"
+                aria-expanded="false"
+                aria-controls={`${id}-content`}
+                onClick={(e) => {
+                    const details = e.currentTarget.parentElement as HTMLDetailsElement;
+                    e.currentTarget.setAttribute("aria-expanded", details.open.toString());
+                }}
+            >
+                {title}
+                <span className="arrow transition-transform">&#9660;</span>
+            </summary>
+            <div id={`${id}-content`} className="module-content p-4">{children}</div>
+        </details>
     );
-}
+};
+
+/* list of modules; can be further expanded later via adding new pages to each list */
+const ModulesContainer: React.FC = () => {
+    return (
+        <div className="modules-container pt-4">
+            <Module title="Module 1: CFR Title 15">
+                <ul className="list-none">
+                    <li><Link href = "education/cfr-title-15">CFR Title 15: Main Information</Link></li>
+                </ul>
+            </Module>
+            <Module title="Module 2: SAM Compliance">
+                <ul className="list-none">
+                    <li><Link href = "education/sam-compliance">SAM Compliance: Main Information</Link></li>
+                </ul>
+            </Module>
+            <Module title="Module 3: SBIR Due Diligence">
+                <ul className="list-none">
+                    <li><Link href = "education/sbir-due-diligence">SBIR Due Diligence: Main Information</Link></li>
+                </ul>
+            </Module>
+            <Module title="Module 4: CMMC">
+                <ul className="list-none">
+                    <li><Link href = "education/cmmc">CMMC 2.0: Main Information</Link></li>
+                </ul>
+            </Module>
+            <Module title="Module 5: FOCI">
+                <ul className="list-none">
+                    <li><Link href = "education/foci">FOCI: Main Information</Link></li>
+                </ul>
+            </Module>
+            <Module title="Module 6: Resources">
+                <ul className="list-none">
+                    <li><Link href = "education/resources">Forms & Links</Link></li>
+                </ul>
+            </Module>
+        </div>
+    );
+};
+
+export default ModulesContainer;

--- a/adversarial_apps/src/app/education/page.tsx
+++ b/adversarial_apps/src/app/education/page.tsx
@@ -10,10 +10,10 @@ type ModuleProps = {
 const Module: React.FC<ModuleProps> = ({ title, children }) => {
     const id = title.replace(/\s+/g, '-').toLowerCase();
     return (
-        <details className="module w-full max-w-lg mx-auto rounded-lg shadow-md overflow-hidden mb-4 border-2 border-solid">
+        <details className="module w-full max-w-lg mx-auto rounded-lg shadow-md overflow-hidden mb-4 border-2 border-solid text-white">
             <summary
                 id={`${id}-title`} 
-                className="module-header bg-blue-800 p-4 cursor-pointer flex justify-between items-center text-lg"
+                className="module-header bg-blue-900 p-4 cursor-pointer flex justify-between items-center text-lg"
                 aria-expanded="false"
                 aria-controls={`${id}-content`}
                 onClick={(e) => {

--- a/adversarial_apps/src/app/education/page.tsx
+++ b/adversarial_apps/src/app/education/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React from "react";
+import React, { useState } from "react";
 import Link from "next/link";
 
 type ModuleProps = {
@@ -9,27 +9,31 @@ type ModuleProps = {
 
 const Module: React.FC<ModuleProps> = ({ title, children }) => {
     const id = title.replace(/\s+/g, '-').toLowerCase();
+    const [isOpen, setIsOpen] = useState(false);
+
     return (
-        <details className="module w-full max-w-lg mx-auto rounded-lg shadow-md overflow-hidden mb-4 border-2 border-solid text-white">
+        <details 
+            className={`module w-full max-w-lg mx-auto rounded-lg shadow-md overflow-hidden mb-4 border-2 border-solid text-white ${isOpen ? 'bg-gray-800' : 'bg-transparent'}`} 
+            open={isOpen}
+            onToggle={(e) => setIsOpen(e.currentTarget.open)}
+        >
             <summary
                 id={`${id}-title`} 
-                className="module-header bg-blue-900 p-4 cursor-pointer flex justify-between items-center text-lg"
-                aria-expanded="false"
+                className={`module-header bg-blue-900 p-4 cursor-pointer flex justify-between items-center text-lg focus:text-yellow-300 focus:font-bold`}
+                aria-expanded={isOpen} 
                 aria-controls={`${id}-content`}
-                onClick={(e) => {
-                    const details = e.currentTarget.parentElement as HTMLDetailsElement;
-                    e.currentTarget.setAttribute("aria-expanded", details.open.toString());
-                }}
             >
                 {title}
-                <span className="arrow transition-transform">&#9660;</span>
+                <span className={`arrow transition-transform ${isOpen ? "rotate-90" : "rotate-270"}`}>
+                    &#9654;
+                </span>
             </summary>
-            <div id={`${id}-content`} className="module-content p-4">{children}</div>
+            <div id={`${id}-content`} className="module-content p-4 bg-gray-800">{children}</div>
         </details>
     );
 };
 
-/* list of modules; can be further expanded later via adding new pages to each list */
+{/* list of modules; can be further expanded later via adding new pages to each list */}
 const ModulesContainer: React.FC = () => {
     return (
         <div className="modules-container pt-4">

--- a/adversarial_apps/src/app/education/resources/page.tsx
+++ b/adversarial_apps/src/app/education/resources/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 export default function page(){
     return (
         <main aria-label="main-content">
@@ -21,6 +22,14 @@ export default function page(){
                 <a href="https://www.ecfr.gov/current/title-15/" target="_blank"> <u>Click here for link</u></a></p>
             <p className = "pl-5"><br />Federal Acquisition Regulation (FAR) Documentation:
                 <a href="https://www.acquisition.gov/browse/index/far" target="_blank"> <u>Click here for link</u></a></p>
+
+            {/* copy paste the below button(s) for each subpage */}
+            <div className="container py-10 px-10 mx-0 min-w-full flex flex-col items-center">
+                <button className="bg-blue-700 hover:bg-blue-900 text-white font-bold py-2 px-4 rounded"
+                        aria-label="Back to Education Hub">
+                    <Link href = "/education">Back to Education Hub</Link>
+                </button>
+            </div>
         </main>
     );
 }

--- a/adversarial_apps/src/app/education/resources/page.tsx
+++ b/adversarial_apps/src/app/education/resources/page.tsx
@@ -25,7 +25,7 @@ export default function page(){
 
             {/* copy paste the below buttons for each subpage; make sure to relink */}
             <div className="container py-10 px-10 mx-0 min-w-full flex justify-center items-center space-x-4">
-                <Link href = "/education" passHref legacyBehavior>
+                <Link href = "/education/foci" passHref legacyBehavior>
                     <button className="bg-blue-700 hover:bg-blue-900 text-white font-bold py-2 px-4 rounded"
                         aria-label="Previous Page">
                         Previous Page

--- a/adversarial_apps/src/app/education/resources/page.tsx
+++ b/adversarial_apps/src/app/education/resources/page.tsx
@@ -25,10 +25,12 @@ export default function page(){
 
             {/* copy paste the below button(s) for each subpage */}
             <div className="container py-10 px-10 mx-0 min-w-full flex flex-col items-center">
-                <button className="bg-blue-700 hover:bg-blue-900 text-white font-bold py-2 px-4 rounded"
+                <Link href = "/education">
+                    <button className="bg-blue-700 hover:bg-blue-900 text-white font-bold py-2 px-4 rounded"
                         aria-label="Back to Education Hub">
-                    <Link href = "/education">Back to Education Hub</Link>
-                </button>
+                        Back to Education Hub
+                    </button>
+                </Link>
             </div>
         </main>
     );

--- a/adversarial_apps/src/app/education/resources/page.tsx
+++ b/adversarial_apps/src/app/education/resources/page.tsx
@@ -39,12 +39,6 @@ export default function page(){
                     </button>
                 </Link>
 
-                <Link href = "/education" passHref legacyBehavior>
-                    <button className="bg-blue-700 hover:bg-blue-900 text-white font-bold py-2 px-4 rounded"
-                        aria-label="Next Page">
-                        Next Page
-                    </button>
-                </Link>
             </div>
         </main>
     );

--- a/adversarial_apps/src/app/education/resources/page.tsx
+++ b/adversarial_apps/src/app/education/resources/page.tsx
@@ -23,12 +23,26 @@ export default function page(){
             <p className = "pl-5"><br />Federal Acquisition Regulation (FAR) Documentation:
                 <a href="https://www.acquisition.gov/browse/index/far" target="_blank"> <u>Click here for link</u></a></p>
 
-            {/* copy paste the below button(s) for each subpage */}
-            <div className="container py-10 px-10 mx-0 min-w-full flex flex-col items-center">
-                <Link href = "/education">
+            {/* copy paste the below buttons for each subpage; make sure to relink */}
+            <div className="container py-10 px-10 mx-0 min-w-full flex justify-center items-center space-x-4">
+                <Link href = "/education" passHref legacyBehavior>
+                    <button className="bg-blue-700 hover:bg-blue-900 text-white font-bold py-2 px-4 rounded"
+                        aria-label="Previous Page">
+                        Previous Page
+                    </button>
+                </Link>
+
+                <Link href = "/education" passHref legacyBehavior>
                     <button className="bg-blue-700 hover:bg-blue-900 text-white font-bold py-2 px-4 rounded"
                         aria-label="Back to Education Hub">
                         Back to Education Hub
+                    </button>
+                </Link>
+
+                <Link href = "/education" passHref legacyBehavior>
+                    <button className="bg-blue-700 hover:bg-blue-900 text-white font-bold py-2 px-4 rounded"
+                        aria-label="Next Page">
+                        Next Page
                     </button>
                 </Link>
             </div>

--- a/adversarial_apps/src/app/education/sam-compliance/page.tsx
+++ b/adversarial_apps/src/app/education/sam-compliance/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 export default function page(){
     return (
         <main aria-label="main-content">
@@ -21,6 +22,14 @@ export default function page(){
             <p className = "pl-5">Simply renew your business registration annually, using your past registration
                 information. Any updates to business policies that are relevant to SAM should be updated
                 in SAM immediately.</p>
+
+            {/* copy paste the below button(s) for each subpage */}
+            <div className="container py-10 px-10 mx-0 min-w-full flex flex-col items-center">
+                <button className="bg-blue-700 hover:bg-blue-900 text-white font-bold py-2 px-4 rounded"
+                        aria-label="Back to Education Hub">
+                    <Link href = "/education">Back to Education Hub</Link>
+                </button>
+            </div>
         </main>
     );
 }

--- a/adversarial_apps/src/app/education/sam-compliance/page.tsx
+++ b/adversarial_apps/src/app/education/sam-compliance/page.tsx
@@ -25,10 +25,12 @@ export default function page(){
 
             {/* copy paste the below button(s) for each subpage */}
             <div className="container py-10 px-10 mx-0 min-w-full flex flex-col items-center">
-                <button className="bg-blue-700 hover:bg-blue-900 text-white font-bold py-2 px-4 rounded"
+                <Link href = "/education">
+                    <button className="bg-blue-700 hover:bg-blue-900 text-white font-bold py-2 px-4 rounded"
                         aria-label="Back to Education Hub">
-                    <Link href = "/education">Back to Education Hub</Link>
-                </button>
+                        Back to Education Hub
+                    </button>
+                </Link>
             </div>
         </main>
     );

--- a/adversarial_apps/src/app/education/sam-compliance/page.tsx
+++ b/adversarial_apps/src/app/education/sam-compliance/page.tsx
@@ -25,7 +25,7 @@ export default function page(){
 
             {/* copy paste the below buttons for each subpage; make sure to relink */}
             <div className="container py-10 px-10 mx-0 min-w-full flex justify-center items-center space-x-4">
-                <Link href = "/education" passHref legacyBehavior>
+                <Link href = "/education/cfr-title-15" passHref legacyBehavior>
                     <button className="bg-blue-700 hover:bg-blue-900 text-white font-bold py-2 px-4 rounded"
                         aria-label="Previous Page">
                         Previous Page
@@ -39,7 +39,7 @@ export default function page(){
                     </button>
                 </Link>
 
-                <Link href = "/education" passHref legacyBehavior>
+                <Link href = "/education/sbir-due-diligence" passHref legacyBehavior>
                     <button className="bg-blue-700 hover:bg-blue-900 text-white font-bold py-2 px-4 rounded"
                         aria-label="Next Page">
                         Next Page

--- a/adversarial_apps/src/app/education/sam-compliance/page.tsx
+++ b/adversarial_apps/src/app/education/sam-compliance/page.tsx
@@ -23,12 +23,26 @@ export default function page(){
                 information. Any updates to business policies that are relevant to SAM should be updated
                 in SAM immediately.</p>
 
-            {/* copy paste the below button(s) for each subpage */}
-            <div className="container py-10 px-10 mx-0 min-w-full flex flex-col items-center">
-                <Link href = "/education">
+            {/* copy paste the below buttons for each subpage; make sure to relink */}
+            <div className="container py-10 px-10 mx-0 min-w-full flex justify-center items-center space-x-4">
+                <Link href = "/education" passHref legacyBehavior>
+                    <button className="bg-blue-700 hover:bg-blue-900 text-white font-bold py-2 px-4 rounded"
+                        aria-label="Previous Page">
+                        Previous Page
+                    </button>
+                </Link>
+
+                <Link href = "/education" passHref legacyBehavior>
                     <button className="bg-blue-700 hover:bg-blue-900 text-white font-bold py-2 px-4 rounded"
                         aria-label="Back to Education Hub">
                         Back to Education Hub
+                    </button>
+                </Link>
+
+                <Link href = "/education" passHref legacyBehavior>
+                    <button className="bg-blue-700 hover:bg-blue-900 text-white font-bold py-2 px-4 rounded"
+                        aria-label="Next Page">
+                        Next Page
                     </button>
                 </Link>
             </div>

--- a/adversarial_apps/src/app/education/sbir-due-diligence/page.tsx
+++ b/adversarial_apps/src/app/education/sbir-due-diligence/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 export default function page(){
     return (
         <main aria-label="main-content">
@@ -52,6 +53,14 @@ export default function page(){
                 publication on May 23rd, 2024 with the subject &quot;Defense Small Business Innovation Research 
                 and Small Business Technology Transfer Due Diligence Program&quot;. See the link labeled &quot;SBIR 
                 Due Diligence Memorandum (May 2024)&quot; in Forms and Resources for more details.</p>
+            
+            {/* copy paste the below button(s) for each subpage */}
+            <div className="container py-10 px-10 mx-0 min-w-full flex flex-col items-center">
+                <button className="bg-blue-700 hover:bg-blue-900 text-white font-bold py-2 px-4 rounded"
+                        aria-label="Back to Education Hub">
+                    <Link href = "/education">Back to Education Hub</Link>
+                </button>
+            </div>
         </main>
     );
 }

--- a/adversarial_apps/src/app/education/sbir-due-diligence/page.tsx
+++ b/adversarial_apps/src/app/education/sbir-due-diligence/page.tsx
@@ -56,10 +56,12 @@ export default function page(){
             
             {/* copy paste the below button(s) for each subpage */}
             <div className="container py-10 px-10 mx-0 min-w-full flex flex-col items-center">
-                <button className="bg-blue-700 hover:bg-blue-900 text-white font-bold py-2 px-4 rounded"
+                <Link href = "/education">
+                    <button className="bg-blue-700 hover:bg-blue-900 text-white font-bold py-2 px-4 rounded"
                         aria-label="Back to Education Hub">
-                    <Link href = "/education">Back to Education Hub</Link>
-                </button>
+                        Back to Education Hub
+                    </button>
+                </Link>
             </div>
         </main>
     );

--- a/adversarial_apps/src/app/education/sbir-due-diligence/page.tsx
+++ b/adversarial_apps/src/app/education/sbir-due-diligence/page.tsx
@@ -54,12 +54,26 @@ export default function page(){
                 and Small Business Technology Transfer Due Diligence Program&quot;. See the link labeled &quot;SBIR 
                 Due Diligence Memorandum (May 2024)&quot; in Forms and Resources for more details.</p>
             
-            {/* copy paste the below button(s) for each subpage */}
-            <div className="container py-10 px-10 mx-0 min-w-full flex flex-col items-center">
-                <Link href = "/education">
+            {/* copy paste the below buttons for each subpage; make sure to relink */}
+            <div className="container py-10 px-10 mx-0 min-w-full flex justify-center items-center space-x-4">
+                <Link href = "/education" passHref legacyBehavior>
+                    <button className="bg-blue-700 hover:bg-blue-900 text-white font-bold py-2 px-4 rounded"
+                        aria-label="Previous Page">
+                        Previous Page
+                    </button>
+                </Link>
+
+                <Link href = "/education" passHref legacyBehavior>
                     <button className="bg-blue-700 hover:bg-blue-900 text-white font-bold py-2 px-4 rounded"
                         aria-label="Back to Education Hub">
                         Back to Education Hub
+                    </button>
+                </Link>
+
+                <Link href = "/education" passHref legacyBehavior>
+                    <button className="bg-blue-700 hover:bg-blue-900 text-white font-bold py-2 px-4 rounded"
+                        aria-label="Next Page">
+                        Next Page
                     </button>
                 </Link>
             </div>

--- a/adversarial_apps/src/app/education/sbir-due-diligence/page.tsx
+++ b/adversarial_apps/src/app/education/sbir-due-diligence/page.tsx
@@ -56,7 +56,7 @@ export default function page(){
             
             {/* copy paste the below buttons for each subpage; make sure to relink */}
             <div className="container py-10 px-10 mx-0 min-w-full flex justify-center items-center space-x-4">
-                <Link href = "/education" passHref legacyBehavior>
+                <Link href = "/education/sam-compliance" passHref legacyBehavior>
                     <button className="bg-blue-700 hover:bg-blue-900 text-white font-bold py-2 px-4 rounded"
                         aria-label="Previous Page">
                         Previous Page
@@ -70,7 +70,7 @@ export default function page(){
                     </button>
                 </Link>
 
-                <Link href = "/education" passHref legacyBehavior>
+                <Link href = "/education/cmmc" passHref legacyBehavior>
                     <button className="bg-blue-700 hover:bg-blue-900 text-white font-bold py-2 px-4 rounded"
                         aria-label="Next Page">
                         Next Page

--- a/adversarial_apps/src/components/navbar.tsx
+++ b/adversarial_apps/src/components/navbar.tsx
@@ -18,9 +18,9 @@ const EducationSubNavBar = ({ isSubMenuOpen }: { isSubMenuOpen: boolean }) => {
         <li><Link href="/education/cfr-title-15" className="block py-1 hover:bg-blue-700 px-2 whitespace-nowrap">CFR Title 15</Link></li>
         <li><Link href="/education/sam-compliance" className="block py-1 hover:bg-blue-700 px-2 whitespace-nowrap">SAM Compliance</Link></li>
         <li><Link href="/education/sbir-due-diligence" className="block py-1 hover:bg-blue-700 px-2 whitespace-nowrap">SBIR Due Diligence</Link></li>
-        <li><Link href="/education/resources" className="block py-1 hover:bg-blue-700 px-2 whitespace-nowrap">Resources</Link></li>
-        <li><Link href="/education/cmmc" className="block py-1 hover:bg-blue-700 px-2 whitespace-nowrap">CMMC 2.0</Link></li>
+        <li><Link href="/education/cmmc" className="block py-1 hover:bg-blue-700 px-2 whitespace-nowrap">CMMC</Link></li>
         <li><Link href="/education/foci" className="block py-1 hover:bg-blue-700 px-2 whitespace-nowrap">FOCI</Link></li>
+        <li><Link href="/education/resources" className="block py-1 hover:bg-blue-700 px-2 whitespace-nowrap">Resources</Link></li>
       </ul>
     </div>
   );

--- a/adversarial_apps/src/tests/components/navbar.test.tsx
+++ b/adversarial_apps/src/tests/components/navbar.test.tsx
@@ -15,8 +15,8 @@ describe('NavBar', () => {
     expect(screen.getByRole('link', { name: /CFR Title 15/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /SAM Compliance/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /SBIR Due Diligence/i })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /Resources/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /CMMC 2\.0/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /FOCI/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Resources/i })).toBeInTheDocument();
   });
 });

--- a/adversarial_apps/src/tests/components/navbar.test.tsx
+++ b/adversarial_apps/src/tests/components/navbar.test.tsx
@@ -15,7 +15,7 @@ describe('NavBar', () => {
     expect(screen.getByRole('link', { name: /CFR Title 15/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /SAM Compliance/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /SBIR Due Diligence/i })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /CMMC 2\.0/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /CMMC/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /FOCI/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Resources/i })).toBeInTheDocument();
   });

--- a/adversarial_apps/tsconfig.json
+++ b/adversarial_apps/tsconfig.json
@@ -1,6 +1,10 @@
 {
   "compilerOptions": {
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -18,9 +22,19 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
-    }
+      "@/*": [
+        "./src/*"
+      ]
+    },
+    "target": "ES2017"
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "Adversarial-Apps-Web",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
added "Back to Education Hub" buttons on each page, reconfigured education hub to be module-style Webcourses format, reordered education topics on navbar
NOTE: Back to Education Hub buttons do not navigate to the correct page, if someone could look at how I can redirect the user back to the education hub that'd be great. For now I'm just sending it back to the dashboard. Might rename the buttons to "Back to Dashboard".

# Proposed Changes

* see above

Fixes #83 .
