### PR TITLE
Fix for Items Rendering on NavBar

### DIFF
--- a/adversarial_apps/src/components/navbar.tsx
+++ b/adversarial_apps/src/components/navbar.tsx
@@ -251,7 +251,7 @@ export default function NavBar() {
   }, []);
 
   return (
-    <header className="sticky top-0 bg-blue-900 grid grid-cols-3 items-center p-1 shadow-md border-b-2">
+    <header className="sticky top-0 bg-blue-900 grid grid-cols-3 items-center p-1 shadow-md border-b-2 z-50">
       {/* Logo */}
       <div className="flex justify-start ml-4">
         <Link href="/" aria-label="Go to home page">


### PR DESCRIPTION
# Proposed Changes

Added "z-50" to the nav bar div which increases the height above any other component or icon. 

The two items that rendered on top of navbar when you scrolled were the QR Code Icon in the Dashboard and the "Risk Score" text in the company page. With the fix these items stay under the nav bar at all times.
