### PR TITLE
188 edit apis to add company name to db

### DIFF
--- a/adversarial_apps/src/app/api/call-python-api/python-calls/database.py
+++ b/adversarial_apps/src/app/api/call-python-api/python-calls/database.py
@@ -531,7 +531,7 @@ def generate_excel(username: str) -> dict:
     }
 
 
-def request_company_review(username: str, identifier: str, source: str) -> dict:
+def request_company_review(username: str, identifier: str, source: str, entityName: str) -> dict:
     """
     Process a review request for a company:
     - Retrieves the user's ID from the USERS table.
@@ -573,10 +573,16 @@ def request_company_review(username: str, identifier: str, source: str) -> dict:
         company_row = cursor.fetchone()
         if not company_row:
             # Insert the company with default values if it doesn't exist.
-            cursor.execute(
-                f'INSERT INTO "{table}" ("{id_column}", "isVerified", "riskScore", "review_requests") VALUES (%s, %s, %s, %s)',
-                (identifier, False, 0, 0),
-            )
+            if table == "COMPANIES":
+                cursor.execute(
+                    f'INSERT INTO "{table}" ("{id_column}", "isVerified", "riskScore", "review_requests", "entityName") VALUES (%s, %s, %s, %s, %s)',
+                    (identifier, False, 0, 0, entityName),
+                )
+            else:
+                cursor.execute(
+                    f'INSERT INTO "{table}" ("{id_column}", "isVerified", "riskScore", "review_requests") VALUES (%s, %s, %s, %s)',
+                    (identifier, False, 0, 0),
+                )
             connection.commit()  # Commit the new company insertion.
 
         # 3. Check if the user has already requested a review for this company.

--- a/adversarial_apps/src/app/api/call-python-api/python-calls/database.py
+++ b/adversarial_apps/src/app/api/call-python-api/python-calls/database.py
@@ -349,7 +349,7 @@ def get_company_score(identifier: str, source: str) -> dict:
         return {"status": "error", "message": f"Database error: {e}"}
 
 
-def update_company_score(identifier: str, source: str, risk_score: float) -> dict:
+def update_company_score(identifier: str, source: str, risk_score: float, entityName: str) -> dict:
     """
     Update the risk score for a company based on the identifier (CIK or UEI) and source.
 
@@ -376,11 +376,18 @@ def update_company_score(identifier: str, source: str, risk_score: float) -> dic
 
             # Insert if it doesn't exist
             if not company_exists:
-                insert_query = f"""
-                    INSERT INTO "{table}" ("{id_column}", "isVerified", "riskScore", "lastVerified", "review_requests")
-                    VALUES (%s, %s, %s, NOW(), 0)
-                """
-                insert_values = (identifier, False, 0)
+                if table == "COMPANIES":
+                    insert_query = f"""
+                    INSERT INTO "{table}" ("{id_column}", "isVerified", "riskScore", "lastVerified", "review_requests", "entityName")
+                    VALUES (%s, %s, %s, NOW(), 0, %s)
+                    """
+                    insert_values = (identifier, False, 0, entityName)
+                else:
+                    insert_query = f"""
+                        INSERT INTO "{table}" ("{id_column}", "isVerified", "riskScore", "lastVerified", "review_requests")
+                        VALUES (%s, %s, %s, NOW(), 0)
+                    """
+                    insert_values = (identifier, False, 0)
                 cursor.execute(insert_query, insert_values)
                 connection.commit()
 

--- a/adversarial_apps/src/app/api/call-python-api/python-calls/database.py
+++ b/adversarial_apps/src/app/api/call-python-api/python-calls/database.py
@@ -153,7 +153,9 @@ def get_reviewer_status(username: str) -> dict:
     }
 
 
-def add_remove_favorite(username: str, identifier: str, source: str, entityName: str) -> dict:
+def add_remove_favorite(
+    username: str, identifier: str, source: str, entityName: str
+) -> dict:
     """
     Add or remove a favorite company for the user, supporting both SEC and SAM companies.
 
@@ -349,7 +351,9 @@ def get_company_score(identifier: str, source: str) -> dict:
         return {"status": "error", "message": f"Database error: {e}"}
 
 
-def update_company_score(identifier: str, source: str, risk_score: float, entityName: str) -> dict:
+def update_company_score(
+    identifier: str, source: str, risk_score: float, entityName: str
+) -> dict:
     """
     Update the risk score for a company based on the identifier (CIK or UEI) and source.
 
@@ -538,7 +542,9 @@ def generate_excel(username: str) -> dict:
     }
 
 
-def request_company_review(username: str, identifier: str, source: str, entityName: str) -> dict:
+def request_company_review(
+    username: str, identifier: str, source: str, entityName: str
+) -> dict:
     """
     Process a review request for a company:
     - Retrieves the user's ID from the USERS table.

--- a/adversarial_apps/src/app/api/call-python-api/python-calls/database.py
+++ b/adversarial_apps/src/app/api/call-python-api/python-calls/database.py
@@ -153,7 +153,7 @@ def get_reviewer_status(username: str) -> dict:
     }
 
 
-def add_remove_favorite(username: str, identifier: str, source: str) -> dict:
+def add_remove_favorite(username: str, identifier: str, source: str, entityName: str) -> dict:
     """
     Add or remove a favorite company for the user, supporting both SEC and SAM companies.
 
@@ -195,8 +195,8 @@ def add_remove_favorite(username: str, identifier: str, source: str) -> dict:
             # do the the CIK in FAVORITES table is a foreign key to the CIK in COMPANIES table
             if source == "SEC":
                 cursor.execute(
-                    'INSERT INTO "COMPANIES" ("CIK", "isVerified", "riskScore") VALUES (%s, %s, %s)',
-                    (identifier, False, 0),
+                    'INSERT INTO "COMPANIES" ("CIK", "isVerified", "riskScore", "entityName") VALUES (%s, %s, %s, %s)',
+                    (identifier, False, 0, entityName),
                 )
             connection.commit()
 

--- a/adversarial_apps/src/app/api/call-python-api/python-calls/main_api.py
+++ b/adversarial_apps/src/app/api/call-python-api/python-calls/main_api.py
@@ -201,6 +201,7 @@ if __name__ == "__main__":
                 input_action_and_data.get("identifier"),
                 input_action_and_data.get("source"),
                 input_action_and_data.get("risk_score"),
+                input_action_and_data.get("entityName"),
             )
         elif action == "get_def_url":
             # Expecting JSON like { "action": "get_def_url", "cik": "0000123456" }

--- a/adversarial_apps/src/app/api/call-python-api/python-calls/main_api.py
+++ b/adversarial_apps/src/app/api/call-python-api/python-calls/main_api.py
@@ -215,6 +215,7 @@ if __name__ == "__main__":
                 input_action_and_data.get("username"),
                 input_action_and_data.get("identifier"),
                 input_action_and_data.get("source"),
+                input_action_and_data.get("entityName"),
             )
         elif action == "get_review_requests":
             result = get_review_requests()

--- a/adversarial_apps/src/app/api/call-python-api/python-calls/main_api.py
+++ b/adversarial_apps/src/app/api/call-python-api/python-calls/main_api.py
@@ -164,6 +164,7 @@ if __name__ == "__main__":
                 input_action_and_data.get("username"),
                 input_action_and_data.get("identifier"),
                 input_action_and_data.get("source"),
+                input_action_and_data.get("entityName"),
             )
         elif action == "get_favorites":
             # Then the inputActionAndData is formatted as such:

--- a/adversarial_apps/src/app/company/[cik]/page.tsx
+++ b/adversarial_apps/src/app/company/[cik]/page.tsx
@@ -174,6 +174,7 @@ export default async function page({ params }: CompanyDetailsProps) {
                 source="SEC"
                 username={username}
                 favorites={favorites || []}
+                entityName={name}
               />
             </div>
           </div>

--- a/adversarial_apps/src/app/company/[cik]/page.tsx
+++ b/adversarial_apps/src/app/company/[cik]/page.tsx
@@ -272,6 +272,7 @@ export default async function page({ params }: CompanyDetailsProps) {
                 source="SEC"
                 username={username || null}
                 role={reviewerData?.role || null}
+                entityName={name}
               />
             </div>
           )}

--- a/adversarial_apps/src/app/company/[cik]/page.tsx
+++ b/adversarial_apps/src/app/company/[cik]/page.tsx
@@ -315,7 +315,7 @@ export default async function page({ params }: CompanyDetailsProps) {
           )}
 
           {reviewerData && reviewerData.role === "true" && (
-            <UpdateCompany identifier={cik} source="SEC" />
+            <UpdateCompany identifier={cik} source="SEC" entityName={name} />
           )}
         </div>
       </div>

--- a/adversarial_apps/src/components/FavoriteButton.tsx
+++ b/adversarial_apps/src/components/FavoriteButton.tsx
@@ -9,10 +9,11 @@ interface Props {
   source: "SEC" | "SAM"; // Company type
   username: string;
   favorites: string[];
+  entityName: string;
 }
 
 export const FavoriteButton = (props: Props) => {
-  const { identifier, source, username, favorites } = props;
+  const { identifier, source, username, favorites, entityName } = props;
 
   const [isFavorite, setIsFavorite] = useState(favorites.includes(identifier));
   const [showLoginMessage, setShowLoginMessage] = useState(false);
@@ -30,6 +31,7 @@ export const FavoriteButton = (props: Props) => {
             username,
             identifier,
             source, // Send either CIK or UEI
+            entityName,
           }),
         });
 

--- a/adversarial_apps/src/components/RequestReviewButton.tsx
+++ b/adversarial_apps/src/components/RequestReviewButton.tsx
@@ -10,6 +10,7 @@ interface RequestReviewButtonProps {
   source: "SEC" | "SAM";
   username: string | null;
   role: string | null; // Expected values: "TRUE" or "FALSE"
+  entityName: string | null;
 }
 
 export default function RequestReviewButton({
@@ -17,6 +18,7 @@ export default function RequestReviewButton({
   source,
   username,
   role,
+  entityName,
 }: RequestReviewButtonProps) {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
@@ -52,6 +54,7 @@ export default function RequestReviewButton({
           username,
           identifier,
           source,
+          entityName,
         };
         const response = await fetch("/api/call-python-api", {
           method: "POST",

--- a/adversarial_apps/src/components/UpdateCompany.tsx
+++ b/adversarial_apps/src/components/UpdateCompany.tsx
@@ -7,11 +7,13 @@ import { toast } from "react-toastify";
 interface VerifyButtonProps {
   identifier: string; // CIK for SEC, UEI for SAM
   source: "SEC" | "SAM"; // New prop to indicate the source
+  entityName: string;
 }
 
 export default function VerifyUpdate({
   identifier,
   source,
+  entityName,
 }: VerifyButtonProps) {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
@@ -35,6 +37,7 @@ export default function VerifyUpdate({
         identifier, // CIK or UEI
         source, // SEC or SAM
         risk_score: numericScore,
+        entityName,
       }; // Use state value
 
       console.log("Submitting Data:", data);


### PR DESCRIPTION
# Proposed Changes

Updated APIs so that they update the entityName field in the COMPANIES table whenever they add a company to that table

The 3 APIs that I found that add companies to the table are:
* add_remove_favorite
* update_company_score
* request_company_review
