### PR TITLE
New Tab Name

### DIFF
--- a/adversarial_apps/src/app/layout.tsx
+++ b/adversarial_apps/src/app/layout.tsx
@@ -3,6 +3,11 @@ import NavBar from "@/components/navbar";
 import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 
+export const metadata = {
+  title: "Adversarial Apps",
+  description: "We offer an extensive database with powerful search tools to locate business partners that meet federal contracting security standards for U.S.-based supply chains.",
+};
+
 export default function RootLayout({
   children,
 }: Readonly<{


### PR DESCRIPTION
# Proposed Changes

* Added Tab Name so it doesn't just say the current website.
* Added Description for search engines.

Example of the difference:
<img width="287" alt="image" src="https://github.com/user-attachments/assets/aade3f2b-c480-4613-a75e-2616e02685d5" />