### PR TITLE
fixes searchbar to not overlap navbar

### DIFF
--- a/adversarial_apps/src/components/searchbar.tsx
+++ b/adversarial_apps/src/components/searchbar.tsx
@@ -182,7 +182,7 @@ function SearchBarContent({ placeholder }: { placeholder: string }) {
 
   return (
     // Changing this to just "flex", does not display the results correctly.
-    <div className="relative flex z-50">
+    <div className="relative flex z-40">
       <label htmlFor="search" className="sr-only">
         Search
       </label>


### PR DESCRIPTION
# Proposed Changes

* Searchbar still has a more front z-axis, but it is still less than navbar's 50.

Fixes # .
